### PR TITLE
Add Poker Share project to portfolio

### DIFF
--- a/netlify/functions/ga4-visitors.cjs
+++ b/netlify/functions/ga4-visitors.cjs
@@ -13,6 +13,7 @@ const PROJECT_HOSTNAMES = {
   'portfolio': 'harigo.me',
   'daily-habits': 'daily.harigo.me',
   'poker-planner': 'planner.harigo.me',
+  'poker-share': 'share.harigo.me',
 };
 
 exports.handler = async (event, context) => {

--- a/src/components/ContentProjects.astro
+++ b/src/components/ContentProjects.astro
@@ -42,13 +42,15 @@ const projects: Project[] = [{
     },
     id: 'poker-planner'
 }, {
-    name: 'Undisclosed Poker Project',
-    description: 'A website for sharing poker hands that happened in real life.',
+    name: 'Poker Share',
+    description: 'A website for sharing poker hands that happened in real life. Currently in alpha version.',
     link: {
-        buttonLabel: 'Coming Soon',
-        url: '',
+        url: 'https://share.harigo.me',
+        target: '_blank',
+        title: 'Poker Share',
+        buttonLabel: 'View Project'
     },
-    id: 'undisclosed'
+    id: 'poker-share'
 }];
 ---
 


### PR DESCRIPTION
## Summary
- Add the newly deployed Poker Share application to the projects section
- Replace the "Undisclosed Poker Project" placeholder with live project details
- Configure analytics tracking for visitor counts

## Changes
- **Project listing**: Updated project name, description, and added link to share.harigo.me
- **Alpha notice**: Added note that the project is currently in alpha version
- **GA4 tracking**: Added hostname mapping for analytics visitor count display

## Test plan
- [ ] Verify project displays correctly in the projects grid
- [ ] Confirm "View Project" button links to share.harigo.me
- [ ] Check that GA4 visitor count fetches for the new project (after deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)