### PR TITLE
Fix certification cards overflow on narrow screens

### DIFF
--- a/src/components/ContentCertifications.astro
+++ b/src/components/ContentCertifications.astro
@@ -62,13 +62,13 @@ const certifications: Certification[] = [{
                     )}
 
                     <!-- Content -->
-                    <div class="flex-grow">
+                    <div class="flex-grow min-w-0">
 
-                        <h3 class="text-lg font-semibold text-white mb-1">
+                        <h3 class="text-lg font-semibold text-white mb-1 break-words">
                             {cert.name}
                         </h3>
 
-                        <p class="text-gray-400 text-sm mb-2">
+                        <p class="text-gray-400 text-sm mb-2 break-words">
                             {cert.issuer}
                         </p>
 
@@ -78,7 +78,7 @@ const certifications: Certification[] = [{
                         </p>
 
                         {cert.credentialId && (
-                            <p class="text-gray-600 text-xs mb-3">
+                            <p class="text-gray-600 text-xs mb-3 break-all">
                                 Credential ID: {cert.credentialId}
                             </p>
                         )}


### PR DESCRIPTION
## Summary
- Fixed text overflow issue in certification cards on narrow screens
- Added `min-w-0` to flex container for proper shrinking behavior
- Added `break-words` to title and issuer text for natural wrapping
- Added `break-all` to credential ID to handle long unbreakable strings

## Problem
On narrow screens, the second certification card (AWS Certified Cloud Practitioner) would overflow its container due to the long credential ID string (`f28a135811694ce59ad3083b90e5995a`) not breaking properly.

## Solution
Applied proper text overflow handling using Tailwind utility classes to ensure content stays within container boundaries at all screen sizes.

## Test plan
- [ ] View certs.json tab on narrow screen (mobile viewport)
- [ ] Verify all certification cards stay within bounds
- [ ] Check that credential IDs wrap properly without overflow
- [ ] Test across different viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)