### PR TITLE
Add shareable chat link with hash-based URL

### DIFF
--- a/src/components/ChatModal.astro
+++ b/src/components/ChatModal.astro
@@ -254,6 +254,10 @@
         if (chatModal) {
             chatModal.classList.add('hidden');
             chatModal.classList.remove('flex');
+            // Remove hash from URL
+            if (window.location.hash === '#chat') {
+                history.pushState('', document.title, window.location.pathname + window.location.search);
+            }
         }
     }
 
@@ -276,6 +280,11 @@
 
     // Listen for open chat modal event
     window.addEventListener('open-chat-modal', openChatModal);
+
+    // Auto-open modal if URL has #chat hash
+    if (window.location.hash === '#chat') {
+        openChatModal();
+    }
 
     // Handle form submission
     chatForm?.addEventListener('submit', async (e) => {

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -102,6 +102,7 @@ const { displayDate: cvLastUpdated, fileName: cvFileName } = cvMetadata.default;
 
     <script>
         document.getElementById('open-chat-button')?.addEventListener('click', () => {
+            window.location.hash = 'chat';
             window.dispatchEvent(new CustomEvent('open-chat-modal'));
         });
     </script>


### PR DESCRIPTION
## Summary
This PR adds the ability to share a direct link to the chat interface using a hash-based URL (`harigo.me/#chat`).

## Changes
- Auto-open chat modal when URL contains `#chat` hash
- Set hash to `#chat` when chat button is clicked
- Remove hash from URL when modal is closed

## How it works
- **Normal use**: Click button → Modal opens → URL becomes `harigo.me/#chat`
- **Direct link**: Share `harigo.me/#chat` → Modal auto-opens on page load
- **Close**: Click X or Escape → Modal closes → URL returns to `harigo.me/`

## Shareable URL
Recruiters can now be sent `harigo.me/#chat` directly, and the chat modal will automatically open when they visit the link.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)